### PR TITLE
Change deislabs organization references to project-akri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # TODO: Change this to Akri main when the library is merged
-akri-discovery-utils = { git = "https://github.com/deislabs/akri", branch = "main", package = "akri-discovery-utils" }
+akri-discovery-utils = { git = "https://github.com/project-akri/akri", branch = "main", package = "akri-discovery-utils" }
 async-trait = "0.1.0"
 tokio = { version = "1.0.1", features = ["time", "net", "sync"] }
 tonic = { version = "0.5.2", features = ["tls"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Akri Discovery Handler Template
-A template for accelerating creating a Discovery Handler for [Akri](https://github.com/deislabs/akri) in Rust. 
+A template for accelerating creating a Discovery Handler for [Akri](https://github.com/project-akri/akri) in Rust. 
 
 ## About
 A Discovery Handler is anything that implements Akri's the `Discover` service and `Registration` client defined in
-Akri's [discovery gRPC interface](https://github.com/deislabs/akri/blob/main/discovery-utils/proto/discovery.proto).
+Akri's [discovery gRPC interface](https://github.com/project-akri/akri/blob/main/discovery-utils/proto/discovery.proto).
 This can be done in any language using Akri's proto file. This template creates a `DiscoveryHandler` that implements the
 `Discover` service and registers it with the Akri Agent.
 
@@ -34,7 +34,7 @@ This template is pulled via the [`cargo-generate`](https://github.com/cargo-gene
     ```
 1. Deploy Akri with your custom Discovery Handler
     ```sh
-    helm repo add akri-helm-charts https://deislabs.github.io/akri/
+    helm repo add akri-helm-charts https://project-akri.github.io/akri/
     helm install akri akri-helm-charts/akri-dev \
     --set imagePullSecrets[0].name="crPullSecret" \
     --set custom.discovery.enabled=true  \


### PR DESCRIPTION
Since Akri was moved to a new home under `project-akri`, urls need to be changed.

Relates To: https://github.com/project-akri/akri-docs/issues/83