### PR TITLE
make docker build platform independent

### DIFF
--- a/Dockerfile.discovery-handler
+++ b/Dockerfile.discovery-handler
@@ -1,4 +1,5 @@
-FROM amd64/rust:1.54 as build
+FROM docker.io/rust:1.63.0-alpine3.15 as build
+RUN apk add g++ openssl-dev protoc
 RUN rustup component add rustfmt --toolchain 1.54.0-x86_64-unknown-linux-gnu
 RUN USER=root cargo new --bin dh
 WORKDIR /dh
@@ -10,9 +11,8 @@ RUN cargo build --release && \
 COPY ./src ./src
 RUN cargo build --release
 
-FROM amd64/debian:buster-slim
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends libssl-dev && \
-    apt-get clean
+FROM docker.io/alpine:3.15
+RUN apk add openssl-dev
+
 COPY --from=build /dh/target/release/{{project-name}} /{{project-name}}
 ENTRYPOINT ["/{{project-name}}"]


### PR DESCRIPTION
The old docker file doesn't work for arm64 platforms (esp macs with M1)